### PR TITLE
Flame is now a namespace instead of an Object. Update transformations/bindings.

### DIFF
--- a/flame.js
+++ b/flame.js
@@ -7,5 +7,5 @@
 //= require ./repeater
 //= require ./validations
 
-window.Flame = Ember.Object.create({});
+window.Flame = Ember.Namespace.create({});
 

--- a/utils/bindings.js
+++ b/utils/bindings.js
@@ -8,8 +8,13 @@ Ember.mixin(Ember.Binding.prototype, {
 
     // If value evaluates to true, return trueValue, otherwise falseValue
     transformTrueFalse: function(trueValue, falseValue) {
-        return this.transform(function(value, binding) {
-            return value ? trueValue : falseValue;
+        return this.transform({
+            to: function(value) {
+                return value ? trueValue : falseValue;
+            },
+            from: function(value) {
+                return !!(value === trueValue);
+            }
         });
     },
 

--- a/utils/prefixed_binding.js
+++ b/utils/prefixed_binding.js
@@ -112,9 +112,14 @@ Flame.reopen({
         var bindingPropertyName = propertyName + 'Binding';
 
         while (!Ember.none(cur)) {
-            if (cur.hasOwnProperty(propertyName) ||
-                cur.constructor.prototype.hasOwnProperty(propertyName) ||
-                cur.get(bindingPropertyName)) {
+            // It seems that earlier (at least 0.9.4) the constructor of the view contained pleothra of properties,
+            // but nowadays (at least 0.9.6) the properties are there throughout the prototype-chain ant not in the
+            // last prototype. Thus testing whether current objects prototype has the property does not give correct
+            // results.
+            // So we check if the current object has the property (perhaps some of its prototypes has it) or it has
+            // a binding for the property and in case it has, this object is the target of our binding.
+            if (typeof Ember.get(cur, propertyName) !== "undefined"
+                    || typeof Ember.get(cur, bindingPropertyName) !== "undefined") {
                 return path.reverse().join('.');
             }
             path.push('parentView');

--- a/views/menu_view.js
+++ b/views/menu_view.js
@@ -142,8 +142,7 @@ Flame.MenuView = Flame.Panel.extend(Flame.ActionSupport, {
                 // Push strings to rendering buffer with one pushObjects call so we don't get one arrayWill/DidChange
                 // per menu item.
                 var tempArr = items.map(function(menuItem) { return menuItem.renderToElement(); });
-                var alreadyRenderedChildren = renderingBuffer.get('childBuffers');
-                alreadyRenderedChildren.pushObjects(tempArr);
+                renderingBuffer.push(tempArr.join(''));
             }
         });
     },


### PR DESCRIPTION
Miscellaneous fixes:
- MenuView doesn't use innards of RenderBuffer that are no longer available.
- Flame is now a namespace so we get nicer names for widgets
- Update prefix bindings to use just getters so we can (perhaps) bind to unknownProperty-properties and to values that are further up in the prototype-chain.
