### PR TITLE
Make ListView more handlebars friendly

### DIFF
--- a/view.js
+++ b/view.js
@@ -77,8 +77,8 @@ Flame.View = Ember.ContainerView.extend(Flame.LayoutSupport, Flame.EventManager,
         }
     },
 
-    template: function(property_name, value) {
-        if (property_name == "template" && value !== undefined) return value;
+    template: function(propertyName, value) {
+        if (propertyName === "template" && value !== undefined) return value;
         var str = this.get('handlebars');
         return str ? this._compileTemplate(str) : null;
     }.property('templateName', 'handlebars').cacheable(),

--- a/views/list_view.js
+++ b/views/list_view.js
@@ -20,11 +20,11 @@ Flame.ListView = Flame.CollectionView.extend(Flame.Statechart, {
     initialState: 'idle',
     reorderDelegate: null,
 
-    temViewClass: Flame.ListItemView.extend({
+    itemViewClass: Flame.ListItemView.extend({
         contentBinding: "*content",
-        templateContext: Ember.computed(function(key, value) {
-            return value !== undefined ? value : get(this, 'content');
-        }).cacheable(),
+        templateContext: function(key, value) {
+            return value !== undefined ? value : Ember.get(this, 'content');
+        }.property().cacheable(),
         templateBinding: "parentView.template",
         handlebars: "{{title}}"
     }),


### PR DESCRIPTION
So it is now possible:

``` html
{{#view Flame.ListView contentBinding="App.selectItems"}}
         {{id}}
{{/view}}
```

{{id}} being the template used for each ListItemView.

That won't matter to the "JS" version of your UI, because you were overriding itemViewClass anyway.
