### PR TITLE
 Ensure removal of orphaned emptyViews

### DIFF
--- a/views/collection_view.js
+++ b/views/collection_view.js
@@ -1,3 +1,21 @@
 Flame.CollectionView =  Ember.CollectionView.extend(Flame.LayoutSupport, Flame.EventManager, {
-    classNames: ['flame-list-view']
+    classNames: ['flame-list-view'],
+
+    init: function() {
+        this._super();
+        var emptyViewClass = this.get('emptyView');
+        if (emptyViewClass) {
+            emptyViewClass.reopen({
+                // Ensures removal if orphaned, circumventing the emptyView issue
+                // (https://github.com/emberjs/ember.js/issues/233)
+                ensureEmptyViewRemoval: function() {
+                    if (!this.get('parentView')) {
+                        Ember.run.next(this, 'remove');
+                    }
+                }.observes('parentView')
+            });
+
+        }
+    }
+
 });


### PR DESCRIPTION
Ensures removal of CollectionView's emptyView instances that are orphaned but are still left hanging in DOM.
