### PR TITLE
Support using TAB to cycle focus between controls in the FormView

### DIFF
--- a/stylesheets/mixins.css.scss
+++ b/stylesheets/mixins.css.scss
@@ -41,6 +41,7 @@
 
 @mixin control-blur() {
     @include box-shadow(0, 0, 4, #0066cc);
+    border-color: #448CD4\9 !important; // IE only hack
 }
 
 @mixin border-radius($radius) {

--- a/views/text_area_view.js
+++ b/views/text_area_view.js
@@ -4,6 +4,7 @@ Flame.TextAreaView = Flame.View.extend({
     layout: { left: 0, top: 0 },
     defaultHeight: 20,
     defaultWidth: 200,
+    acceptsKeyResponder: true,
 
     value: '',
     placeholder: null,

--- a/views/text_field_view.js
+++ b/views/text_field_view.js
@@ -6,6 +6,7 @@
 Flame.TextFieldView = Flame.View.extend(Flame.ActionSupport, {
     classNames: ['flame-text'],
     childViews: ['textField'],
+    acceptsKeyResponder: true,
 
     layout: { left: 0, top: 0 },
     defaultHeight: 22,


### PR DESCRIPTION
It would be better to have TAB support for all controls on the page, but this is a temporary and easy fix to make it work for FormViews only, which is where I guess tabbing between controls is most often used.
