### PR TITLE
Call remove() only for non-destroyed emptyViews in ensureEmptyViewRemoval

### DIFF
--- a/views/collection_view.js
+++ b/views/collection_view.js
@@ -10,7 +10,9 @@ Flame.CollectionView =  Ember.CollectionView.extend(Flame.LayoutSupport, Flame.E
                 // (https://github.com/emberjs/ember.js/issues/233)
                 ensureEmptyViewRemoval: function() {
                     if (!this.get('parentView')) {
-                        Ember.run.next(this, 'remove');
+                        Ember.run.next(this, function() {
+                            if (!this.get('isDestroyed')) this.remove();
+                        });
                     }
                 }.observes('parentView')
             });


### PR DESCRIPTION
Right now ensureEmptyViewRemoval does not check if emptyView is already destroyed. This should fix that.
