### PR TITLE
Update Flame to work with Ember >= 0.9.6 (at least partially)

### DIFF
--- a/mixins/action_support.js
+++ b/mixins/action_support.js
@@ -15,9 +15,8 @@ Flame.ActionSupport = {
     payload: null,
 
     fireAction: function(action, payload) {
-        var target = this.get('target') || null;
+        var target = this.get('target') || this;
 
-        if (!target) { target = this; }
         while ('string' === typeof target) {  // Use a while loop: the target can be a path gives another path
             if (target.charAt(0) === '.') {
                 target = this.getPath(target.slice(1));  // If starts with a dot, interpret relative to this view
@@ -28,7 +27,7 @@ Flame.ActionSupport = {
         if (action === undefined) { action = this.get('action'); }
 
         if (action) {
-            var actionFunction = 'function' === typeof action ? action : target[action];
+            var actionFunction = 'function' === typeof action ? action : Ember.get(target, action);
             if (!actionFunction) throw 'Target %@ does not have action %@'.fmt(target, action);
             return actionFunction.call(target, payload || this.get('payload') || this, action, this);
         }

--- a/utils/prefixed_binding.js
+++ b/utils/prefixed_binding.js
@@ -113,7 +113,7 @@ Flame.reopen({
 
         while (!Ember.none(cur)) {
             // It seems that earlier (at least 0.9.4) the constructor of the view contained pleothra of properties,
-            // but nowadays (at least 0.9.6) the properties are there throughout the prototype-chain ant not in the
+            // but nowadays (at least 0.9.6) the properties are there throughout the prototype-chain and not in the
             // last prototype. Thus testing whether current objects prototype has the property does not give correct
             // results.
             // So we check if the current object has the property (perhaps some of its prototypes has it) or it has

--- a/view.js
+++ b/view.js
@@ -70,7 +70,7 @@ Flame.View = Ember.ContainerView.extend(Flame.LayoutSupport, Flame.EventManager,
         var template = this.get('template');
         if (template) {
             // Copied from Ember.View for now
-            var output = template(this.get('templateContext'), { data: { view: this, buffer: buffer, isRenderData: true } });
+            var output = template(this.get('templateContext'), { data: { view: this, buffer: buffer, isRenderData: true, keywords: {} } });
             if (output !== undefined) { buffer.push(output); }
         } else {
             return this._super(buffer);


### PR DESCRIPTION
Basically, two changes:
- data `template`-function uses is now expected to have keywords-property.
- Prototype-chains have been altered so its better to use Ember.get than to try to directly read the property from an object.
