### PR TITLE
Add a simple way to measure text height and width via Flame.measureString

### DIFF
--- a/utils/string_measurement.js
+++ b/utils/string_measurement.js
@@ -1,0 +1,32 @@
+Ember.mixin(Flame, {
+    
+    _setupStringMeasurement: function(parentClasses, elementClasses) {
+        if (!parentClasses) {
+            parentClasses = '';
+        }
+        if (!elementClasses) {
+            elementClasses = '';
+        }
+        var element = this._metricsCalculationElement;
+        if (!element) {
+            var parentElement = document.createElement("div");
+            parentElement.style.cssText = "position:absolute;left:-10010px; top:-10px; width:10000px; visibility:hidden;";
+            element = this._metricsCalculationElement = document.createElement("div");
+            element.style.cssText = "position:absolute; left: 0px; top: 0px; bottom: auto; right: auto; width: auto; height: auto;";
+            parentElement.appendChild(element);
+            document.body.insertBefore(parentElement, null);
+        }
+        element.parentNode.className = parentClasses;
+        element.className = elementClasses;
+        return element;
+    },
+   
+   measureString: function(string, parentClasses, elementClasses) {
+        var element = this._setupStringMeasurement(parentClasses, elementClasses);
+        element.innerHTML = string;
+        return {
+            width: element.clientWidth,
+            height: element.clientHeight
+        };
+   }
+});

--- a/views/menu_view.js
+++ b/views/menu_view.js
@@ -75,6 +75,7 @@ Flame.MenuView = Flame.Panel.extend(Flame.ActionSupport, {
     itemHeight: 21,
     /* Margin between the menu and top/bottom of the viewport. */
     menuMargin: 12,
+    minWidth: null, // Defines minimum width of menu
     items: [],
     parentMenu: null,
     value: null,
@@ -91,6 +92,20 @@ Flame.MenuView = Flame.Panel.extend(Flame.ActionSupport, {
     init: function() {
         this._super();
         this._needToRecreateItems();
+    },
+
+    _calculateMenuWidth: function() {
+        var items = this.get("items");
+        if (Ember.get(items, 'length') === 0) {
+            return;
+        }
+        var itemTitleKey = this.get("itemTitleKey");
+        var allTitles = items.reduce(function(currentTitles, item) {
+            var nextTitle = Ember.get(item, itemTitleKey);
+            return currentTitles + nextTitle + '<br/>';
+        }, '');
+        // Give the menus a 16px breathing space to account for sub menu indicator, and to give some right margin
+        return Flame.measureString(allTitles, 'ember-view flame-view flame-list-item-view flame-menu-item-view', 'title').width + 16;
     },
 
     _createMenuItems: function() {
@@ -235,6 +250,8 @@ Flame.MenuView = Flame.Panel.extend(Flame.ActionSupport, {
             needScrolling = true;
         }
         layout.set("height", menuOuterHeight);
+        var menuWidth = Math.max(this.get('minWidth') || 0, this._calculateMenuWidth());
+        layout.set("width", menuWidth);
         this.set("layout", layout);
         this.get("contentView").set("needScrolling", needScrolling);
     },

--- a/views/select_button_view.js
+++ b/views/select_button_view.js
@@ -54,6 +54,7 @@ Flame.SelectButtonView = Flame.ButtonView.extend({
             subMenuKey: this.get('subMenuKey'),
             itemsBinding: 'selectButtonView.items',
             valueBinding: 'selectButtonView.value',
+            minWidth: this.getPath('layout.width') || this.$().width(),
             close: function() {
                 self.gotoState('idle');
                 this._super();


### PR DESCRIPTION
You should supply the classes for the parent elements, and the classes for the element you want to measure. This isn't enough to emulate complicated stylesheets with immediate child selectors (>), but might be good enough for the majority of cases.
