### PR TITLE
Adding a cursor to the panel resize

### DIFF
--- a/stylesheets/flame.css.scss
+++ b/stylesheets/flame.css.scss
@@ -223,6 +223,7 @@ body {
 
     .flame-resize-thumb {
         background-image: image-url('images/resize_thumb.png');
+        cursor: sw-resize;
     }
 }
 


### PR DESCRIPTION
Uses CSS to change the cursor when the user mouses over the resize box, as an extra cue that there's something to drag here.
