### PR TITLE
Straighten split views

### DIFF
--- a/stylesheets/flame.css.scss
+++ b/stylesheets/flame.css.scss
@@ -365,7 +365,7 @@ body {
     }
 }
 
-.flame-horizontal-split-view {
+.flame-vertical-split-view {
     .flame-split-view-divider {
         border-style: none solid none solid;
         @include horizontal-gradient(#f7f7f7, #d8d8d8);
@@ -373,7 +373,7 @@ body {
     }
 }
 
-.flame-vertical-split-view {
+.flame-horizontal-split-view {
     .flame-split-view-divider {
         border-style: solid none solid none;
         @include vertical-gradient(#f7f7f7, #d8d8d8);

--- a/views/horizontal_split_view.js
+++ b/views/horizontal_split_view.js
@@ -5,7 +5,7 @@
  * dividerView.
  */
 Flame.HorizontalSplitView = Flame.SplitView.extend({
-    classNames: 'flame-vertical-split-view'.w(), // TODO: Legacy CSS class name
+    classNames: 'flame-horizontal-split-view'.w(),
     childViews: 'topView dividerView bottomView'.w(),
     topHeight: 100,
     bottomHeight: 100,

--- a/views/vertical_split_view.js
+++ b/views/vertical_split_view.js
@@ -5,7 +5,7 @@
  * dividerView.
  */
 Flame.VerticalSplitView = Flame.SplitView.extend({
-    classNames: 'flame-horizontal-split-view'.w(), // TODO: fix legacy CSS class naming
+    classNames: 'flame-vertical-split-view'.w(),
     childViews: 'leftView dividerView rightView'.w(),
     leftWidth: 100,
     rightWidth: 100,


### PR DESCRIPTION
This fixes flamejs/flame.js#48 .

First, the renaming of the SplitViews had me providing the wrong sub-views - I was passing topView and bottomView to VerticalSplitView, and it's now HorizontalSplitView which uses these. Because of my Ember.assert PR just before this, the assert testing this was actually enforcing the wrong names here. That's cleared up in this PR. There's a working jsFiddle here: http://jsfiddle.net/pjmorse/qwaZs/9/

Second, the css classnames were confusing (because we were using the old CSS, which had the wrong gradients for the new Horizontal/Vertical naming). I've straightened that in this PR as well.
