### PR TITLE
Closer binding of divider-view CSS with the parent view

### DIFF
--- a/stylesheets/flame.css.scss
+++ b/stylesheets/flame.css.scss
@@ -375,20 +375,16 @@ body {
     }
 }
 
-.flame-vertical-split-view {
-    .flame-split-view-divider {
-        border-style: none solid none solid;
-        @include horizontal-gradient(#f7f7f7, #d8d8d8);
-        cursor: col-resize;
-    }
+.flame-vertical-split-view > .flame-split-view-divider {
+    border-style: none solid none solid;
+    @include horizontal-gradient(#f7f7f7, #d8d8d8);
+    cursor: col-resize;
 }
 
-.flame-horizontal-split-view {
-    .flame-split-view-divider {
-        border-style: solid none solid none;
-        @include vertical-gradient(#f7f7f7, #d8d8d8);
-        cursor: row-resize;
-    }
+.flame-horizontal-split-view > .flame-split-view-divider {
+    border-style: solid none solid none;
+    @include vertical-gradient(#f7f7f7, #d8d8d8);
+    cursor: row-resize;
 }
 
 .flame-split-view-divider {


### PR DESCRIPTION
If there are nested *SplitViews, all the DividerViews descended from a HorizontalSplitView use the CSS for that divider, even if they're dividing a VerticalSplitView, because both rules apply (the DividerView is a descendent of both a HorizontalSplitView and a VerticalSplitView). This applies the divider-view CSS to children of the relevant SplitViews, not just descendants.
