### PR TITLE
Ensure that list view reflects initial selection properly

### DIFF
--- a/views/list_view.js
+++ b/views/list_view.js
@@ -19,6 +19,10 @@ Flame.ListView = Flame.CollectionView.extend(Flame.Statechart, {
     selection: undefined,
     initialState: 'idle',
     reorderDelegate: null,
+    init: function() {
+        this._super();
+        this._selectionDidChange();
+    },
 
     itemViewClass: Flame.ListItemView.extend({
         templateContext: function(key, value) {


### PR DESCRIPTION
If there is a selection property set on the list view at the time the view is created, it was not being represented properly, until the selection property changed. This change fixes that.
