### PR TITLE
Convert getPath/setPath to get/set as the former has been deprecated in Ember master

### DIFF
--- a/controllers/array_table_controller.js
+++ b/controllers/array_table_controller.js
@@ -39,7 +39,7 @@ Flame.ArrayTableController = Flame.DataTableController.extend(Flame.TableSortSup
                 };
             }),
             columnHeaders: this.get('columns').map(function(column, i) {
-                return {label: Ember.getPath(column, 'label'), property: Ember.getPath(column, 'property')};
+                return {label: Ember.get(column, 'label'), property: Ember.get(column, 'property')};
             })
         };
     }.property('content.@each', 'columns', 'headerProperty', 'rowHeadersClickable').cacheable(),
@@ -50,7 +50,7 @@ Flame.ArrayTableController = Flame.DataTableController.extend(Flame.TableSortSup
         return this.get('content').map(function(object, i) {
             return columns.map(function(column, j) {
                 // add observer for in-place cell refreshing
-                var propertyName = Ember.getPath(column, 'property');
+                var propertyName = Ember.get(column, 'property');
                 var observerMethod = function() {
                     return function(sender, key, value) {
                         self.pushDataBatch([{path: {row: [i], column: [j]}, value: value}]);
@@ -58,7 +58,7 @@ Flame.ArrayTableController = Flame.DataTableController.extend(Flame.TableSortSup
                 }();
                 self._setPropertyObserver(object, propertyName, observerMethod);
 
-                return Ember.get(object, Ember.getPath(column, 'property'));
+                return Ember.get(object, Ember.get(column, 'property'));
             });
         });
     }.property('headers').cacheable(),

--- a/flame_inspector.js
+++ b/flame_inspector.js
@@ -154,7 +154,7 @@ FlameInspector.RefView = Flame.LabelView.extend({
     },
 
     currentState: function() {
-        return this.getPath('ownerObject.currentState') === this.get('content');
+        return this.get('ownerObject.currentState') === this.get('content');
     }.property('ownerObject.currentState').cacheable(),
 
     typeClass: function() {
@@ -278,9 +278,9 @@ FlameInspector.EventLogView = Flame.View.extend({
             render: function(buffer) {
                 this._super(buffer);
                 var html = '<div style="background-color: %@"><div class="flame-inspector-event-name">%@</div><div class="flame-inspector-event-info">%@</div></div>'.fmt(
-                    this.getPath('content.color'),
-                    this.getPath('content.eventName'),
-                    this.getPath('content.info')
+                    this.get('content.color'),
+                    this.get('content.eventName'),
+                    this.get('content.info')
                 );
                 buffer.push(html);
             }
@@ -486,7 +486,7 @@ FlameInspector.InspectorController = Ember.Object.extend({
     },
 
     allowNext: function() {
-        return this.get('_historyIndex') < this.getPath('_inspectHistory.length') - 1;
+        return this.get('_historyIndex') < this.get('_inspectHistory.length') - 1;
     }.property('_historyIndex'),
 
     inspectedObject: function() {
@@ -705,7 +705,7 @@ FlameInspector.DebugPanel = Flame.Panel.extend({
     currentInspectorView: null,
 
     inspectedObjectWillChange: function() {
-        this.getPath('contentView.inspector').removeFromParent();
+        this.get('contentView.inspector').removeFromParent();
         if (this.get('currentInspectorView')) {
             this.get('currentInspectorView').destroy();
             this.set('currentInspectorView', null);
@@ -714,7 +714,7 @@ FlameInspector.DebugPanel = Flame.Panel.extend({
 
     inspectedObjectDidChange: function() {
         var contentView = this.get('contentView');
-        var type = this.getPath('inspectorController.inspectedObjectType');
+        var type = this.get('inspectorController.inspectedObjectType');
         var newInspectorViewClass = FlameInspector.inspectorViewMap[type];
         if (!newInspectorViewClass) newInspectorViewClass = FlameInspector.inspectorViewMap.object;  // Default to object inspector
         var newInspectorView = contentView.createChildView(newInspectorViewClass.extend({targetBinding: 'parentView.parentView.inspectorController'}));

--- a/mixins/action_support.js
+++ b/mixins/action_support.js
@@ -19,9 +19,9 @@ Flame.ActionSupport = {
 
         while ('string' === typeof target) {  // Use a while loop: the target can be a path gives another path
             if (target.charAt(0) === '.') {
-                target = this.getPath(target.slice(1));  // If starts with a dot, interpret relative to this view
+                target = this.get(target.slice(1));  // If starts with a dot, interpret relative to this view
             } else {
-                target = Ember.getPath(target);
+                target = Ember.get(target);
             }
         }
         if (action === undefined) { action = this.get('action'); }

--- a/mixins/fullscreen_support.js
+++ b/mixins/fullscreen_support.js
@@ -25,7 +25,7 @@ Flame.FullscreenSupport = {
             // XXX image support in ButtonView?
             handlebars: "<img style='margin: 3px;' src='%@'>".fmt(Flame.image('fullscreen_off.png')),
             action: function() {
-                this.getPath('owner').exitFullscreen();
+                this.get('owner').exitFullscreen();
             }
         });
     }.property(),
@@ -46,7 +46,7 @@ Flame.FullscreenSupport = {
 
             var element = this.$();
             var oldAttributes = {
-                left: element.css('left'), 
+                left: element.css('left'),
                 top: element.css('top'),
                 right: element.css('right'),
                 bottom: element.css('bottom'),

--- a/mixins/layout_support.js
+++ b/mixins/layout_support.js
@@ -93,9 +93,9 @@ Flame.LayoutSupport = {
             if (!Ember.none(value) && 'string' === typeof value && value !== '' && isNaN(parseInt(value, 10))) {
                 // TODO remove the observer when view destroyed?
                 self.addObserver(value, self, function() {
-                    self.adjustLayout(prop, self.getPath(value));
+                    self.adjustLayout(prop, self.get(value));
                 });
-                layout[prop] = self.getPath(value);
+                layout[prop] = self.get(value);
             }
         });
         layout._bindingsResolved = true;

--- a/utils/computed.js
+++ b/utils/computed.js
@@ -1,19 +1,19 @@
 Flame.computed = {
     equals: function(dependentKey, value) {
         return Ember.computed(dependentKey, function() {
-            return value === Ember.getPath(this, dependentKey);
+            return value === Ember.get(this, dependentKey);
         }).cacheable();
     },
 
     notEquals: function(dependentKey, value) {
         return Ember.computed(dependentKey, function() {
-            return value !== Ember.getPath(this, dependentKey);
+            return value !== Ember.get(this, dependentKey);
         }).cacheable();
     },
 
     trueFalse: function(dependentKey, trueValue, falseValue) {
         return Ember.computed(dependentKey, function() {
-            return Ember.getPath(this, dependentKey) ? trueValue : falseValue;
+            return Ember.get(this, dependentKey) ? trueValue : falseValue;
         }).cacheable();
     }
 };
@@ -22,25 +22,25 @@ Flame.computed = {
 // Ember version is used
 Flame.computed.not = function(dependentKey) {
     return Ember.computed(dependentKey, function(key) {
-        return !Ember.getPath(this, dependentKey);
+        return !Ember.get(this, dependentKey);
     }).cacheable();
 };
 
 Flame.computed.empty = function(dependentKey) {
     return Ember.computed(dependentKey, function(key) {
-        var val = Ember.getPath(this, dependentKey);
+        var val = Ember.get(this, dependentKey);
         return val === undefined || val === null || val === '' || (Ember.isArray(val) && Ember.get(val, 'length') === 0);
     }).cacheable();
 };
 
 Flame.computed.bool = function(dependentKey) {
     return Ember.computed(dependentKey, function(key) {
-        return !!Ember.getPath(this, dependentKey);
+        return !!Ember.get(this, dependentKey);
     }).cacheable();
 };
 
 Flame.computed.or = function(dependentKey, otherKey) {
     return Ember.computed(dependentKey, otherKey, function(key) {
-        return Ember.getPath(this, dependentKey) || Ember.getPath(this, otherKey);
+        return Ember.get(this, dependentKey) || Ember.get(this, otherKey);
     }).cacheable();
 };

--- a/utils/handlebars_helpers.js
+++ b/utils/handlebars_helpers.js
@@ -121,7 +121,7 @@ Ember.Handlebars.registerHelper("tableView", function(path){
         hash.columns = data.columns;
     }
 
-    hash.content = Ember.getPath(hash.controller).create({
+    hash.content = Ember.get(hash.controller).create({
         headerProperty: hash.headerProperty,
         columns: hash.columns,
         contentBinding: hash.contentBinding

--- a/utils/sorting_array_proxy.js
+++ b/utils/sorting_array_proxy.js
@@ -77,7 +77,7 @@ Flame.SortingArrayProxy = Ember.ArrayProxy.extend({
         var sortKey = this.get('sortKey');
         this._withObserversSuppressed(function() {
             content.forEach(function(item, i) {
-                Ember.setPath(item, sortKey, i);
+                Ember.set(item, sortKey, i);
             });
         });
     },
@@ -124,7 +124,7 @@ Flame.SortingArrayProxy = Ember.ArrayProxy.extend({
         // situations (reloading, and setting child values), so we check if the sort key really changed, so
         // we don't do unnecessary work
         item.lastPosition = item.get(sortKey);
-        var observer = function() { 
+        var observer = function() {
             this._indexChanged(item);
         };
         Ember.addObserver(item, sortKey, this, observer);
@@ -216,7 +216,7 @@ Flame.SortingArrayProxy = Ember.ArrayProxy.extend({
             var self = this;
             this._withObserversSuppressed(function() {
                 content.forEach(function(item, i) {
-                    Ember.setPath(item, sortKey, i);
+                    Ember.set(item, sortKey, i);
                 });
 
                 for (var i = start; i < start + addCount; i++) {
@@ -242,7 +242,7 @@ Flame.SortingArrayProxy = Ember.ArrayProxy.extend({
     _sort: function(array) {
         var sortKey = this.get('sortKey');
         array.sort(function(o1, o2) {
-            return Ember.compare(Ember.getPath(o1, sortKey), Ember.getPath(o2, sortKey));
+            return Ember.compare(Ember.get(o1, sortKey), Ember.get(o2, sortKey));
         });
     },
 

--- a/utils/table_view_content_adapter.js
+++ b/utils/table_view_content_adapter.js
@@ -2,15 +2,15 @@ Flame.TableViewContentAdapter = Ember.Object.extend({
     content: null,
 
     headers: function() {
-        return this.getPath('content._headers');
+        return this.get('content._headers');
     }.property('content._headers').cacheable(),
 
     columnLeafs: function() {
-        return this.getPath('content.columnLeafs');
+        return this.get('content.columnLeafs');
     }.property('content.columnLeafs').cacheable(),
 
     rowLeafs: function() {
-        return this.getPath('content.rowLeafs');
+        return this.get('content.rowLeafs');
     }.property('content.rowLeafs').cacheable(),
 
     columnHeaderRows: function() {

--- a/views/alert_panel.js
+++ b/views/alert_panel.js
@@ -43,7 +43,7 @@ Flame.AlertPanel.reopen({
             titleBinding: '^cancelButtonTitle',
             isVisibleBinding: '^isCancelVisible',
             action: function() {
-                this.getPath('parentView.parentView').onCancel();
+                this.get('parentView.parentView').onCancel();
             }
         }),
 
@@ -53,7 +53,7 @@ Flame.AlertPanel.reopen({
             isVisibleBinding: '^isConfirmVisible',
             isDefault: true,
             action: function() {
-                this.getPath('parentView.parentView').onConfirm();
+                this.get('parentView.parentView').onConfirm();
             }
         })
     }),

--- a/views/button_view.js
+++ b/views/button_view.js
@@ -14,7 +14,7 @@ Flame.ButtonView = Flame.View.extend(Flame.ActionSupport, Flame.Statechart, {
     handlebars: "<label class='flame-button-label'>{{title}}</label>",
 
     render: function(buffer) {
-        var height = this.getPath('layout.height');
+        var height = this.get('layout.height');
         if (this.get('useAbsolutePosition') && !Ember.none(height)) buffer.style('line-height', (height-2)+'px');  // -2 to account for borders
         this._super(buffer);
     },
@@ -49,7 +49,7 @@ Flame.ButtonView = Flame.View.extend(Flame.ActionSupport, Flame.Statechart, {
         },
 
         mouseDown: function() {
-            if (!this.getPath('owner.isDisabled')) {
+            if (!this.get('owner.isDisabled')) {
                 this.gotoState('mouseDownInside');
             }
             return true;

--- a/views/disclosure_view.js
+++ b/views/disclosure_view.js
@@ -13,8 +13,8 @@ Flame.DisclosureView = Flame.LabelView.extend({
     handlebars: '<img {{bindAttr src="image"}}> {{value}}',
 
     action: function() {
-        var value = this.getPath('visibilityTarget');
-        this.setPath('visibilityTarget', !value);
+        var value = this.get('visibilityTarget');
+        this.set('visibilityTarget', !value);
         return true;
     }
 });

--- a/views/form_view.js
+++ b/views/form_view.js
@@ -87,8 +87,8 @@ Flame.FormView = Flame.View.extend({
     _createChildViewWithLayout: function(view, parent, leftMargin, rightMargin) {
         var childView = parent.createChildView(view);
         if (!childView.get('layout')) childView.set('layout', {});
-        childView.setPath('layout.left', leftMargin);
-        childView.setPath('layout.right', rightMargin);
+        childView.set('layout.left', leftMargin);
+        childView.set('layout.right', rightMargin);
         return childView;
     },
 
@@ -112,7 +112,7 @@ Flame.FormView = Flame.View.extend({
                 var self = this;
                 (buttons || []).forEach(function(descriptor) {
                     var buttonView = self.createChildView(formView._buildButton(descriptor, right));
-                    right += (buttonView.getPath('layout.width') || 0) + 15;
+                    right += (buttonView.get('layout.width') || 0) + 15;
                     childViews.push(buttonView);
                 });
             }

--- a/views/label_view.js
+++ b/views/label_view.js
@@ -10,7 +10,7 @@ Flame.LabelView = Flame.View.extend(Flame.ActionSupport, {
     handlebars: '{{value}}',
 
     render: function(buffer) {
-        var height = this.getPath('layout.height');
+        var height = this.get('layout.height');
         if (this.get('useAbsolutePosition') && !Ember.none(height)) buffer.style('line-height', height+'px');
         this._super(buffer);
     },

--- a/views/list_view.js
+++ b/views/list_view.js
@@ -115,13 +115,13 @@ Flame.ListView = Flame.CollectionView.extend(Flame.Statechart, {
     }.property(),
 
     arrayWillChange: function(content, start, removedCount) {
-        if (!this.getPath('rootTreeView.isDragging')) {
+        if (!this.get('rootTreeView.isDragging')) {
             return this._super.apply(this, arguments);
         }
     },
 
     arrayDidChange: function(content, start, removed, added) {
-        if (!this.getPath('rootTreeView.isDragging')) {
+        if (!this.get('rootTreeView.isDragging')) {
             var result = this._super.apply(this, arguments);
             this._updateContentIndexes();
             return result;
@@ -129,13 +129,13 @@ Flame.ListView = Flame.CollectionView.extend(Flame.Statechart, {
     },
 
     childViewsWillChange: function() {
-        if (!this.getPath('rootTreeView.isDragging')) {
+        if (!this.get('rootTreeView.isDragging')) {
             return this._super.apply(this, arguments);
         }
     },
 
     childViewsDidChange: function() {
-        if (!this.getPath('rootTreeView.isDragging')) {
+        if (!this.get('rootTreeView.isDragging')) {
             return this._super.apply(this, arguments);
         }
     },

--- a/views/list_view_drag_helper.js
+++ b/views/list_view_drag_helper.js
@@ -108,7 +108,7 @@ Flame.ListViewDragHelper = Ember.Object.extend({
 
     finishReorder: function() {
         var itemPathView = this.itemPath.getView();
-        this.get('listView').didReorderContent(itemPathView.getPath('parentView.content'));
+        this.get('listView').didReorderContent(itemPathView.get('parentView.content'));
         itemPathView.set("isDragged", false);
         this.clone.remove();  // Remove the clone holding the clones from the DOM
     },
@@ -133,16 +133,16 @@ Flame.ListViewDragHelper = Ember.Object.extend({
     },
 
     // Moves the dragged element in the list/tree to a new location, possibly under a new parent
-    _moveItem: function(sourcePath, targetPath) {
+    _moveItem: function(sourcePath, target) {
         var view = sourcePath.getView();
         var contentItem = view.get('content');
         var sourceParent = view.get('parentView');
         var sourceContent = sourceParent.get('content');
         var element = view.$();
 
-        var targetView = targetPath.getView();
+        var targetView = target.getView();
         var targetElement = targetView.$();
-        var targetParent = targetPath.position === 'i' ? targetPath.getNestedListView() : targetView.get('parentView');
+        var targetParent = target.position === 'i' ? target.getNestedListView() : targetView.get('parentView');
         var targetContent = targetParent.get('content');
         var targetChildViews = targetParent.get('childViews');
 
@@ -158,19 +158,19 @@ Flame.ListViewDragHelper = Ember.Object.extend({
 
         // Then insert them under the new parent, at the correct position
         var targetIndex = targetView.get('contentIndex');
-        if (targetPath.position === 'b') {
+        if (target.position === 'b') {
             element.insertBefore(targetElement);
             targetChildViews.insertAt(targetIndex, view);
             targetContent.insertAt(targetIndex, contentItem);
-        } else if (targetPath.position === 'a') {
+        } else if (target.position === 'a') {
             element.insertAfter(targetElement);
             targetChildViews.insertAt(targetIndex+1, view);
             targetContent.insertAt(targetIndex+1, contentItem);
-        } else if (targetPath.position === 'i') {
+        } else if (target.position === 'i') {
             targetElement.find('.flame-list-view').first().prepend(element);
             targetChildViews.insertAt(0, view);
             targetContent.insertAt(0, contentItem);
-        } else throw 'Invalid insert position '+targetPath.position;
+        } else throw 'Invalid insert position '+target.position;
 
         if (sourceContent === targetContent && sourceContent.endMoving) sourceContent.endMoving();
         // We need to do this manually because ListView suppresses the childViews observers while dragging,
@@ -249,7 +249,7 @@ Flame.ListViewDragHelper = Ember.Object.extend({
         // If as the last item of a nested list, moving left moves one level up (placing immediately after current parent), OR
         // if the current level isn't valid, try and see if there is a valid drop one level up
         while ((xDiff < -xStep || this._pathInvalid(draggedView, path)) && (path.position === 'a' || this.itemPath.equals(path)) &&
-               path.array.length > 1 && targetView.get('contentIndex') === targetView.getPath('parentView.childViews.length') - 1) {
+               path.array.length > 1 && targetView.get('contentIndex') === targetView.get('parentView.childViews.length') - 1) {
             xDiff += xStep;
             path = path.up();
             targetView = path.getView();
@@ -269,14 +269,14 @@ Flame.ListViewDragHelper = Ember.Object.extend({
         return path;
     },
 
-    _pathInvalid: function(draggedView, targetPath) {
+    _pathInvalid: function(draggedView, target) {
         var itemDragged = draggedView.get('content');
-        var dropTarget = targetPath.getView().get('content');
+        var dropTarget = target.getView().get('content');
         var newParent = null;
-        if (targetPath.position === 'i') {
+        if (target.position === 'i') {
             newParent = dropTarget;
         }  else {
-            var newParentItemView = targetPath.up().getView();
+            var newParentItemView = target.up().getView();
             if (newParentItemView) {
                 newParent = newParentItemView.get('content');
             }
@@ -286,7 +286,7 @@ Flame.ListViewDragHelper = Ember.Object.extend({
     },
 
     _getPrecedingView: function(view) {
-        return view.get('contentIndex') > 0 ? view.getPath('parentView.childViews').objectAt(view.get('contentIndex') - 1) : undefined;
+        return view.get('contentIndex') > 0 ? view.get('parentView.childViews').objectAt(view.get('contentIndex') - 1) : undefined;
     },
 
     _resolvePath: function(view) {
@@ -368,7 +368,7 @@ Flame.ListViewDragHelper.Path = Ember.Object.extend({
     down: function() {
         var newArray = Ember.copy(this.array);
         var newPosition;
-        var nestedChildrenCount = this.getNestedListView().getPath('content.length');
+        var nestedChildrenCount = this.getNestedListView().get('content.length');
         if (nestedChildrenCount > 0) {
             newArray.push(nestedChildrenCount - 1);
             newPosition = 'a';

--- a/views/menu_view.js
+++ b/views/menu_view.js
@@ -139,7 +139,7 @@ Flame.MenuView = Flame.Panel.extend(Flame.ActionSupport, {
                 if (item.isSelected) { this.set("highlightIndex", i); }
             }, this);
         }
-        this.getPath("contentView").setScrolledView(this._createMenuView());
+        this.get("contentView").setScrolledView(this._createMenuView());
         if (this.get("_anchorElement")) {
             this._updateMenuSize();
         }
@@ -368,7 +368,7 @@ Flame.MenuView = Flame.Panel.extend(Flame.ActionSupport, {
     // Propagate internal selection to possible parent
     _internalSelectionDidChange: function() {
         var selected = this.get('internalSelection');
-        Ember.trySetPath(this, "parentMenu.internalSelection", selected);
+        Ember.trySet(this, "parentMenu.internalSelection", selected);
     }.observes('internalSelection'),
 
     _findIndex: function(identityFunc) {

--- a/views/panel.js
+++ b/views/panel.js
@@ -47,7 +47,7 @@ Flame.Panel = Flame.RootView.extend({
         idle: Flame.State.extend({
             mouseDown: function(event) {
                 var owner = this.get('owner');
-                if (!owner.getPath('parentView.allowMoving')) {
+                if (!owner.get('parentView.allowMoving')) {
                     return true;
                 }
                 owner._pageX = event.pageX;
@@ -86,7 +86,7 @@ Flame.Panel = Flame.RootView.extend({
             mouseDown: function(event) {
                 var owner = this.get('owner');
                 var panelElement = owner.get('parentView').$();
-                if (!owner.getPath('parentView.isResizable')) {
+                if (!owner.get('parentView.isResizable')) {
                     return true;
                 }
                 owner._pageX = event.pageX;
@@ -121,7 +121,7 @@ Flame.Panel = Flame.RootView.extend({
 
             parentPanel: null,
             mouseDown: function() {
-                if (this.getPath('parentPanel.allowClosingByClickingOutside')) {
+                if (this.get('parentPanel.allowClosingByClickingOutside')) {
                     this.get('parentPanel').close();
                 }
                 return true;

--- a/views/popover.js
+++ b/views/popover.js
@@ -23,7 +23,7 @@ Flame.Popover = Flame.Panel.extend({
             arrowOffset = offset.top + (anchor.outerHeight() / 2) - parseInt(this.$().css('top').replace('px', ''), 10) - 15;
             arrow.css({ top: arrowOffset + 'px' });
             if (position & Flame.POSITION_LEFT) {
-                arrow.css({ left: this.getPath('layout.width') - 1 + 'px' });
+                arrow.css({ left: this.get('layout.width') - 1 + 'px' });
             }
         }
     },

--- a/views/scroll_view.js
+++ b/views/scroll_view.js
@@ -56,7 +56,7 @@ Flame.ScrollView = Flame.View.extend({
     },
 
     setScrolledView: function(newContent) {
-        this.getPath("viewPort.childViews").replace(0, 1, [newContent]);
+        this.get("viewPort.childViews").replace(0, 1, [newContent]);
     },
 
     scrollPositionDidChange: function() {
@@ -81,7 +81,7 @@ Flame.ScrollView = Flame.View.extend({
     },
 
     _recalculateSizes: function() {
-        var height = this.getPath("parentView.layout.height");
+        var height = this.get("parentView.layout.height");
         if (height > 0) {
             var paddingAndBorders = 5 + 5 + 1 + 1;  // XXX obtain paddings & borders from MenuView?
             this.set("layout", {height: height - paddingAndBorders, width: "100%"});
@@ -118,7 +118,7 @@ Flame.ScrollView = Flame.View.extend({
                 continueScrolling = false;
             }
         } else if (scrollDirection === 1) {
-            var listHeight = this.getPath("viewPort.childViews.firstObject").$().outerHeight();
+            var listHeight = this.get("viewPort.childViews.firstObject").$().outerHeight();
             var shownBottom = oldTop + viewPortHeight;
             if (shownBottom + delta >= listHeight) {
                 delta = listHeight - shownBottom;

--- a/views/select_button_view.js
+++ b/views/select_button_view.js
@@ -20,8 +20,8 @@ Flame.SelectButtonView = Flame.ButtonView.extend({
     }.property("value", "itemValueKey", "subMenuKey", "items").cacheable(),
 
     itemsDidChange: function() {
-        if (this.get('items') && this.getPath('items.length') > 0 && !this._findItem()) {
-            this.set('value', this.getPath('items.firstObject.%@'.fmt(this.get('itemValueKey'))));
+        if (this.get('items') && this.get('items.length') > 0 && !this._findItem()) {
+            this.set('value', this.get('items.firstObject.%@'.fmt(this.get('itemValueKey'))));
         }
     }.observes('items'),
 
@@ -55,7 +55,7 @@ Flame.SelectButtonView = Flame.ButtonView.extend({
             subMenuKey: this.get('subMenuKey'),
             itemsBinding: 'selectButtonView.items',
             valueBinding: 'selectButtonView.value',
-            minWidth: this.getPath('layout.width') || this.$().width(),
+            minWidth: this.get('layout.width') || this.$().width(),
             close: function() {
                 self.gotoState('idle');
                 this._super();

--- a/views/split_view.js
+++ b/views/split_view.js
@@ -8,7 +8,7 @@ Flame.SplitView = Flame.View.extend({
 
         idle: Flame.State.extend({
             mouseDown: function(event) {
-                var parentView = this.getPath('owner.parentView');
+                var parentView = this.get('owner.parentView');
                 if (!parentView.get('allowResizing')) return false;
                 parentView.startResize(event);
                 this.gotoState('resizing');
@@ -16,7 +16,7 @@ Flame.SplitView = Flame.View.extend({
             },
 
             doubleClick: function(event) {
-                var parentView = this.getPath('owner.parentView');
+                var parentView = this.get('owner.parentView');
                 if (!parentView.get('allowResizing')) return false;
                 parentView.toggleCollapse(event);
                 return true;
@@ -25,7 +25,7 @@ Flame.SplitView = Flame.View.extend({
 
         resizing: Flame.State.extend({
             mouseMove: function(event) {
-                this.getPath('owner.parentView').resize(event);
+                this.get('owner.parentView').resize(event);
                 return true;
             },
 

--- a/views/table_data_view.js
+++ b/views/table_data_view.js
@@ -19,8 +19,8 @@ Flame.TableDataView = Flame.View.extend(Flame.Statechart, {
         },
 
         enterState: function() {
-            if (this.getPath('owner.state') === "inDOM") {
-                this.getPath('owner.selection').hide();
+            if (this.get('owner.state') === "inDOM") {
+                this.get('owner.selection').hide();
             }
         }
     }),
@@ -29,7 +29,7 @@ Flame.TableDataView = Flame.View.extend(Flame.Statechart, {
         mouseDown: function(event) {
             var target = jQuery(event.target);
             // If a cell is clicked that was already selected, start editing it
-            if (target.hasClass('table-selection') && this.getPath('owner.selectedDataCell.options')) {
+            if (target.hasClass('table-selection') && this.get('owner.selectedDataCell.options')) {
                 this.startEdit();
                 return true;
             } else return !!this.get('owner').selectCell(target);
@@ -49,7 +49,7 @@ Flame.TableDataView = Flame.View.extend(Flame.Statechart, {
         },
 
         wipeCell: function() {
-            var dataCell = this.getPath('owner.selectedDataCell');
+            var dataCell = this.get('owner.selectedDataCell');
             if (Ember.none(dataCell)) {
                 return;
             }
@@ -64,7 +64,7 @@ Flame.TableDataView = Flame.View.extend(Flame.Statechart, {
         },
 
         startEdit: function(event) {
-            var dataCell = this.getPath('owner.selectedDataCell');
+            var dataCell = this.get('owner.selectedDataCell');
             if (Ember.none(dataCell)) {
                 return;
             }
@@ -81,25 +81,25 @@ Flame.TableDataView = Flame.View.extend(Flame.Statechart, {
         },
 
         moveLeft: function(event) {
-            var selectedCell = this.getPath('owner.selectedCell');
+            var selectedCell = this.get('owner.selectedCell');
             this.get('owner').selectCell(selectedCell.prev());
             return true;
         },
 
         moveRight: function(event) {
-            var selectedCell = this.getPath('owner.selectedCell');
+            var selectedCell = this.get('owner.selectedCell');
             this.get('owner').selectCell(selectedCell.next());
             return true;
         },
 
         moveDown: function(event) {
-            var selectedCell = this.getPath('owner.selectedCell');
+            var selectedCell = this.get('owner.selectedCell');
             this.get('owner').selectCell(jQuery(selectedCell.parent().next().children()[selectedCell.attr('data-index')]));
             return true;
         },
 
         moveUp: function(event) {
-            var selectedCell = this.getPath('owner.selectedCell');
+            var selectedCell = this.get('owner.selectedCell');
             this.get('owner').selectCell(jQuery(selectedCell.parent().prev().children()[selectedCell.attr('data-index')]));
             return true;
         },
@@ -116,7 +116,7 @@ Flame.TableDataView = Flame.View.extend(Flame.Statechart, {
 
         // We need to use the keyPress event, as some browsers don't report the character pressed correctly with keyDown
         keyPress: function(event) {
-            var dataCell = this.getPath('owner.selectedDataCell');
+            var dataCell = this.get('owner.selectedDataCell');
             if (Ember.none(dataCell) || (dataCell && !dataCell.isEditable())) {
                 return false;
             }
@@ -132,7 +132,7 @@ Flame.TableDataView = Flame.View.extend(Flame.Statechart, {
         },
 
         enterState: function() {
-            this.getPath('owner.selection').show();
+            this.get('owner.selection').show();
         }
     }),
 
@@ -200,7 +200,7 @@ Flame.TableDataView = Flame.View.extend(Flame.Statechart, {
         },
 
         exitState: function() {
-            var selection = this.getPath('owner.selection');
+            var selection = this.get('owner.selection');
             selection.html('');
             selection.removeClass('read-only is-selectable');
         },
@@ -260,7 +260,7 @@ Flame.TableDataView = Flame.View.extend(Flame.Statechart, {
             var selectedCell = owner.get('selectedCell');
             var dataCell = owner.get('selectedDataCell');
             var editCell = owner.get('editField');
-            var scrollable = owner.getPath('parentView.scrollable');
+            var scrollable = owner.get('parentView.scrollable');
             var selection = owner.get('selection');
             var options = dataCell.options();
 
@@ -357,7 +357,7 @@ Flame.TableDataView = Flame.View.extend(Flame.Statechart, {
             return;
         }
         var selection = this.get('selection');
-        var scrollable = this.getPath('parentView.scrollable');
+        var scrollable = this.get('parentView.scrollable');
 
         var position = selectedCell.position();
         var scrollTop = scrollable.scrollTop();
@@ -433,7 +433,7 @@ Flame.TableDataView = Flame.View.extend(Flame.Statechart, {
 
     selectCell: function(newSelection) {
         // TODO click can also come from element in a table cell
-        if (this.getPath('parentView.allowSelection') && this.isCellSelectable(newSelection)) {
+        if (this.get('parentView.allowSelection') && this.isCellSelectable(newSelection)) {
             this.set('selectedCell', newSelection);
             return true;
         }
@@ -465,12 +465,12 @@ Flame.TableDataView = Flame.View.extend(Flame.Statechart, {
             return buffer;
         }
         var columnCount = data[0].length;
-        var defaultCellWidth = this.getPath('parentView.defaultColumnWidth');
-        var columnLeafs = this.getPath('parentView.content.columnLeafs');
+        var defaultCellWidth = this.get('parentView.defaultColumnWidth');
+        var columnLeafs = this.get('parentView.content.columnLeafs');
         var cellWidth;
 
         var classes = 'flame-table';
-        if (!this.getPath('parentView.allowSelection')) { classes += ' is-selectable'; }
+        if (!this.get('parentView.allowSelection')) { classes += ' is-selectable'; }
         buffer = buffer.begin('table').attr('class', classes).attr('width', '1px');
         var i, j;
         for (i = 0; i < rowCount; i++) {

--- a/views/table_view.js
+++ b/views/table_view.js
@@ -45,7 +45,7 @@ Flame.TableView = Flame.View.extend(Flame.Statechart, {
     }),
 
     rowDepth: function() {
-        return this.getPath('contentAdapter.rowHeaderRows').map(function(a) {
+        return this.get('contentAdapter.rowHeaderRows').map(function(a) {
             return a.length;
         }).max();
     }.property('contentAdapter.rowHeaderRows').cacheable(),
@@ -60,7 +60,7 @@ Flame.TableView = Flame.View.extend(Flame.Statechart, {
                 owner.set('resizingCell', cell);
                 owner.set('dragStartX', event.pageX);
                 owner.set('startX', parseInt(target.parent().css('width'), 10));
-                owner.set('offset', parseInt(this.getPath('owner.tableCorner').css('width'), 10));
+                owner.set('offset', parseInt(this.get('owner.tableCorner').css('width'), 10));
                 owner.set('type', cell.is('.column-header td') ? 'column' : 'row');
                 return true;
             } else if (!!target.closest('.column-header').length) {
@@ -73,12 +73,12 @@ Flame.TableView = Flame.View.extend(Flame.Statechart, {
         },
 
         mouseUp: function(event) {
-            var clickDelegate = this.getPath('owner.clickDelegate');
+            var clickDelegate = this.get('owner.clickDelegate');
             if (clickDelegate) {
                 var target = jQuery(event.target), index, header;
                 if (!!target.closest('.column-header').length && (index = target.closest('td').attr('data-leaf-index'))) {
                     if (clickDelegate.columnHeaderClicked) {
-                        header = this.getPath('owner.content.columnLeafs')[index];
+                        header = this.get('owner.content.columnLeafs')[index];
                         clickDelegate.columnHeaderClicked(header, target);
                     }
                     return true;
@@ -86,7 +86,7 @@ Flame.TableView = Flame.View.extend(Flame.Statechart, {
                     if (clickDelegate.rowHeaderClicked) {
                         var cell = target.closest('td');
                         index = parseInt(cell.attr('data-index'), 10) / parseInt(cell.attr('rowspan') || 1, 10);
-                        header = this.getPath('owner.content._headers.rowHeaders')[index];
+                        header = this.get('owner.content._headers.rowHeaders')[index];
                         if (!header) { return false; }
                         clickDelegate.rowHeaderClicked(header, target, index);
                     }
@@ -101,18 +101,18 @@ Flame.TableView = Flame.View.extend(Flame.Statechart, {
     resizing: Flame.State.extend({
         mouseMove: function(event) {
             var target = jQuery(event.target);
-            var cell = this.getPath('owner.resizingCell');
-            var deltaX = event.pageX - this.getPath('owner.dragStartX');
-            var cellWidth = this.getPath('owner.startX') + deltaX;
+            var cell = this.get('owner.resizingCell');
+            var deltaX = event.pageX - this.get('owner.dragStartX');
+            var cellWidth = this.get('owner.startX') + deltaX;
             if (cellWidth < 30) { cellWidth = 30; }
             var leafIndex;
             // Adjust size of the cell
-            if (this.getPath('owner.type') === 'column') { // Update data table column width
+            if (this.get('owner.type') === 'column') { // Update data table column width
                 leafIndex = parseInt(cell.attr('data-leaf-index'), 10) + 1;
                 cell.parents('table').find('colgroup :nth-child(%@)'.fmt(leafIndex)).css('width', '%@px'.fmt(cellWidth));
                 this.get('owner')._synchronizeColumnWidth();
             } else {
-                var width = this.getPath('owner.offset') + deltaX - 2;
+                var width = this.get('owner.offset') + deltaX - 2;
                 if (width < 30) { width = 30; }
                 if (jQuery.browser.mozilla) {
                     width -= 1;
@@ -120,11 +120,11 @@ Flame.TableView = Flame.View.extend(Flame.Statechart, {
                     width -= 2;
                 }
                 // Move data table and column header
-                this.getPath('owner.scrollable').css('left', '%@px'.fmt(width));
-                this.getPath('owner.columnHeader').parent().css('left', '%@px'.fmt(width));
-                this.getPath('owner.tableCorner').css('width', '%@px'.fmt(width));
+                this.get('owner.scrollable').css('left', '%@px'.fmt(width));
+                this.get('owner.columnHeader').parent().css('left', '%@px'.fmt(width));
+                this.get('owner.tableCorner').css('width', '%@px'.fmt(width));
                 // Update column width
-                var depth = this.getPath('owner.rowDepth');
+                var depth = this.get('owner.rowDepth');
                 leafIndex = depth - cell.nextAll().length;
                 cell.parents('table').find('colgroup :nth-child(%@)'.fmt(leafIndex)).css('width', '%@px'.fmt(cellWidth));
             }
@@ -191,19 +191,19 @@ Flame.TableView = Flame.View.extend(Flame.Statechart, {
         var renderRowHeader = this.get('renderRowHeader');
         var didRenderTitle = false;
 
-        var headers = this.getPath('contentAdapter.headers');
+        var headers = this.get('contentAdapter.headers');
         if (!headers) {
             return; // Nothing to render
         }
 
-        if (this.getPath('content.title')) {
-            buffer = buffer.push('<div class="panel-title">%@</div>'.fmt(this.getPath('content.title')));
+        if (this.get('content.title')) {
+            buffer = buffer.push('<div class="panel-title">%@</div>'.fmt(this.get('content.title')));
             didRenderTitle = true;
         }
 
         var defaultColumnWidth = this.get('defaultColumnWidth');
-        var columnHeaderRows = this.getPath('contentAdapter.columnHeaderRows');
-        var rowHeaderRows = this.getPath('contentAdapter.rowHeaderRows');
+        var columnHeaderRows = this.get('contentAdapter.columnHeaderRows');
+        var rowHeaderRows = this.get('contentAdapter.rowHeaderRows');
         var columnHeaderHeight = columnHeaderRows.maxDepth * 21 + 1 + columnHeaderRows.maxDepth;
         var leftOffset = 0;
         if (renderRowHeader) {
@@ -234,17 +234,17 @@ Flame.TableView = Flame.View.extend(Flame.Statechart, {
     },
 
     _renderHeader: function(buffer, type, offset, defaultColumnWidth) {
-        var headers = this.getPath('contentAdapter.headers');
+        var headers = this.get('contentAdapter.headers');
         if (!headers) {
             return buffer.begin('div').end();
         }
 
         var position, i;
         if (type === 'column') {
-            headers = this.getPath('contentAdapter.columnHeaderRows');
+            headers = this.get('contentAdapter.columnHeaderRows');
             position = 'left';
         } else {
-            headers = this.getPath('contentAdapter.rowHeaderRows');
+            headers = this.get('contentAdapter.rowHeaderRows');
             position = 'top';
         }
         var length = headers.length;
@@ -257,9 +257,9 @@ Flame.TableView = Flame.View.extend(Flame.Statechart, {
                 buffer = buffer.push('<col style="width: %@px;" class="level-%@" />'.fmt(defaultColumnWidth, i));
             }
         } else {
-            var l = this.getPath('content.columnLeafs').length;
+            var l = this.get('content.columnLeafs').length;
             for (i = 0; i < l; i++) {
-                buffer = buffer.push('<col style="width: %@px;" />'.fmt(this.getPath('content.columnLeafs')[i].get('render_width') || defaultColumnWidth));
+                buffer = buffer.push('<col style="width: %@px;" />'.fmt(this.get('content.columnLeafs')[i].get('render_width') || defaultColumnWidth));
             }
         }
         buffer = buffer.end();
@@ -310,7 +310,7 @@ Flame.TableView = Flame.View.extend(Flame.Statechart, {
                 }
                 label += '</div>';
             } else if (type === 'row') {
-                buffer = buffer.attr('data-index', depth % this.getPath('content.rowLeafs').length);
+                buffer = buffer.attr('data-index', depth % this.get('content.rowLeafs').length);
                 if (this.get('renderColumnHeader')) {
                     if (this.get("isResizable")) {
                         if (header.hasOwnProperty('children')) {

--- a/views/tree_item_view.js
+++ b/views/tree_item_view.js
@@ -16,7 +16,7 @@ Flame.TreeItemView = Flame.ListItemView.extend({
     isExpanded: function(key, value) {
         if (arguments.length === 1) {
             if (this._isExpanded !== undefined) return this._isExpanded;
-            return this.getPath('content.treeItemIsExpanded') || this.get('defaultIsExpanded');
+            return this.get('content.treeItemIsExpanded') || this.get('defaultIsExpanded');
         } else {
             this._isExpanded = value;
             return value;
@@ -25,7 +25,7 @@ Flame.TreeItemView = Flame.ListItemView.extend({
     layout: { left: 0, right: 0, top: 0, height: 0 },
 
     defaultIsExpanded: function() {
-        return this.getPath('parentView.rootTreeView.defaultIsExpanded');
+        return this.get('parentView.rootTreeView.defaultIsExpanded');
     }.property('parentView.rootTreeView.defaultIsExpanded').cacheable(),
 
     // Don't use the list view isSelected highlight logic
@@ -35,7 +35,7 @@ Flame.TreeItemView = Flame.ListItemView.extend({
 
     // This is the highlight logic for tree items, the is-selected class is bound to the flame-tree-item-view-container
     classAttribute: function() {
-        return this.get('content') === this.getPath('parentView.rootTreeView.selection') ? 'flame-tree-item-view-container is-selected' : 'flame-tree-item-view-container';
+        return this.get('content') === this.get('parentView.rootTreeView.selection') ? 'flame-tree-item-view-container is-selected' : 'flame-tree-item-view-container';
     }.property('content', 'parentView.rootTreeView.selection').cacheable(),
 
     // The HTML that we need to produce is a bit complicated, because while nested items should appear
@@ -83,7 +83,7 @@ Flame.TreeItemView = Flame.ListItemView.extend({
             classNames: ['flame-tree-item-view-content'],
             contentIndexBinding: 'parentView.contentIndex',
             handlebars: function() {
-                return this.getPath('parentView.parentView.rootTreeView').handlebarsForItem(this.get('content'));
+                return this.get('parentView.parentView.rootTreeView').handlebarsForItem(this.get('content'));
             }.property('content').cacheable()
         });
     }.property(),
@@ -98,17 +98,17 @@ Flame.TreeItemView = Flame.ListItemView.extend({
     childListView: function() {
         if (this.get("renderSubTree")) {
             // Is there a nicer way to get in touch with child list? This is a bit brittle.
-            return this.getPath("childViews.lastObject.childViews.firstObject");
+            return this.get("childViews.lastObject.childViews.firstObject");
         }
         return null;
     }.property("showsubTree").cacheable(),
 
     hasChildren: function() {
-        return !Ember.none(this.getPath('content.treeItemChildren'));
+        return !Ember.none(this.get('content.treeItemChildren'));
     }.property('content.treeItemChildren'),
 
     mouseUp: function() {
-        if (this.getPath('parentView.rootTreeView.clickTogglesIsExpanded')) {
+        if (this.get('parentView.rootTreeView.clickTogglesIsExpanded')) {
             this.toggleProperty('isExpanded');
         }
         return false;  // Always propagate to ListItemView
@@ -127,15 +127,15 @@ Flame.TreeItemView = Flame.ListItemView.extend({
     // The view class for displaying possible nested list view, in case this item has children.
     nestedTreeView: function() {
         return Flame.TreeView.extend({
-            useAbsolutePosition: this.getPath('parentView.rootTreeView.useAbsolutePositionForItems'),
+            useAbsolutePosition: this.get('parentView.rootTreeView.useAbsolutePositionForItems'),
             layoutManager: Flame.VerticalStackLayoutManager.create({ topMargin: 0, spacing: 0, bottomMargin: 0 }),
             layout: { top: 0, left: 0, right: 0 },
             classNames: ['flame-tree-view-nested'],
             isVisible: Flame.computed.bool('parentView.isExpanded'), // Ember isVisible handling considers undefined to be visible
-            allowSelection: this.getPath('parentView.rootTreeView.allowSelection'),
-            allowReordering: this.getPath('parentView.rootTreeView.allowReordering'),
-            content: this.getPath('content.treeItemChildren'),
-            itemViewClass: this.getPath('parentView.rootTreeView.itemViewClass'),
+            allowSelection: this.get('parentView.rootTreeView.allowSelection'),
+            allowReordering: this.get('parentView.rootTreeView.allowReordering'),
+            content: this.get('content.treeItemChildren'),
+            itemViewClass: this.get('parentView.rootTreeView.itemViewClass'),
             isNested: true
         });
     }.property('content')

--- a/views/tree_view.js
+++ b/views/tree_view.js
@@ -52,7 +52,7 @@ Flame.TreeView = Flame.ListView.extend({
     },
 
     nestingLevel: function() {
-        return 'level-%@'.fmt(this.getPath('treeLevel'));
+        return 'level-%@'.fmt(this.get('treeLevel'));
     }.property('treeLevel'),
 
     // Propagates selection to the parent. This way we can make sure that only exactly one of the nested
@@ -70,7 +70,7 @@ Flame.TreeView = Flame.ListView.extend({
     startReordering: function(dragHelper, event) {
         var parentTreeView = this.get('parentTreeView');
         if (parentTreeView) {
-            dragHelper.get('itemPath').insertAt(0, this.getPath('parentView.contentIndex'));
+            dragHelper.get('itemPath').insertAt(0, this.get('parentView.contentIndex'));
             parentTreeView.startReordering(dragHelper, event);
         } else {
             Flame.set('mouseResponderView', this);  // XXX a bit ugly...
@@ -79,15 +79,15 @@ Flame.TreeView = Flame.ListView.extend({
     },
 
     treeLevel: function() {
-        return (this.getPath('parentTreeView.treeLevel') || 0) + 1;
+        return (this.get('parentTreeView.treeLevel') || 0) + 1;
     }.property('parentTreeView.treeLevel'),
 
     parentTreeView: function() {
-        return this.get('isNested') ? this.getPath('parentView.parentView') : undefined;
+        return this.get('isNested') ? this.get('parentView.parentView') : undefined;
     }.property('isNested', 'parentView.parentView'),
 
     rootTreeView: function() {
-        return this.getPath('parentTreeView.rootTreeView') || this;
+        return this.get('parentTreeView.rootTreeView') || this;
     }.property('parentTreeView.rootTreeView')
 
 });


### PR DESCRIPTION
Not sure what version of Ember you want to target with Flame master. We are using it with master, and so wanted to avoid deprecation warnings related to getPath/setPath. Feel free to apply this, or defer as fits your plan.
