### PR TITLE
Provide dropTarget on isValidDrop call

### DIFF
--- a/views/list_view.js
+++ b/views/list_view.js
@@ -100,10 +100,10 @@ Flame.ListView = Flame.CollectionView.extend(Flame.Statechart, {
         }
     },
 
-    isValidDrop: function(itemDragged, newParent) {
+    isValidDrop: function(itemDragged, newParent, dropTarget) {
         var delegate = this.get('reorderDelegate');
         if (delegate && delegate.isValidDrop) {
-            return delegate.isValidDrop(itemDragged, newParent);
+            return delegate.isValidDrop(itemDragged, newParent, dropTarget);
         } else {
             return true;
         }

--- a/views/list_view_drag_helper.js
+++ b/views/list_view_drag_helper.js
@@ -281,7 +281,7 @@ Flame.ListViewDragHelper = Ember.Object.extend({
                 newParent = newParentItemView.get('content');
             }
         }
-        var isValid = this.get('listView').isValidDrop(itemDragged, newParent);
+        var isValid = this.get('listView').isValidDrop(itemDragged, newParent, dropTarget);
         return !isValid;
     },
 


### PR DESCRIPTION
This change makes the proposed dropTarget get passed to isValidDrop, allowing the listView to make a decision about validity based not just on the parent but on the destination within a list. Also removed an unused method that was probably leftover from an earlier approach. from @lukemelia @DataSurfer 
