### PR TITLE
Allow payload to be falsey value

### DIFF
--- a/mixins/action_support.js
+++ b/mixins/action_support.js
@@ -29,7 +29,9 @@ Flame.ActionSupport = {
         if (action) {
             var actionFunction = 'function' === typeof action ? action : Ember.get(target, action);
             if (!actionFunction) throw 'Target %@ does not have action %@'.fmt(target, action);
-            return actionFunction.call(target, payload || this.get('payload') || this, action, this);
+            var actualPayload = !Ember.none(payload) ? payload : this.get('payload');
+            if (Ember.none(actualPayload)) { actualPayload = this; }
+            return actionFunction.call(target, actualPayload, action, this);
         }
 
         return false;


### PR DESCRIPTION
Payload can now also be `""`, `0` or `NaN` whereas earlier all falsey values were seen as non-existing payload.
