### PR TITLE
Make checkbox label disabled along the checkbox itself when is-disabled

### DIFF
--- a/stylesheets/flame.css.scss
+++ b/stylesheets/flame.css.scss
@@ -149,6 +149,10 @@ body {
         @include no-gradient();
         border: none;
 
+        .flame-checkbox-label {
+          color: #999
+        }
+
         .flame-checkbox-box {
             @include no-gradient();
             background: #EEE;


### PR DESCRIPTION
When only the checkbox is greyed out, it's a bit hard to notice. Greying out the label will make it less ambiguous.
