### PR TITLE
Pinning sprockets version, including Rake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'http://rubygems.org'
 
-gem 'sprockets'
+gem 'rake'
+gem 'sprockets', '~> 2.4.5'
 gem 'sprockets-sass'
 gem 'sass'
 gem 'uglifier'


### PR DESCRIPTION
One of the other gems must have removed its rake dependency, because it was gone from my bundle. I've explicitly included it now.

The Sprockets version pin is what fixes #79 for me.
