### PR TITLE
Make prefix bindings copy all the properties of the original binding.

### DIFF
--- a/utils/prefixed_binding.js
+++ b/utils/prefixed_binding.js
@@ -86,9 +86,13 @@ Flame.reopen({
                     Ember.assert("Property '%@' was not found!".fmt(property), !Ember.none(prefix));
 
                     var finalPath = prefix + suffix;
-                    var newBinding = new Ember.Binding(binding._to, finalPath);
-                    newBinding._transforms = binding._transforms;  // Steal possible transforms
+                    // Copy transformations and the ilk.
+                    var newBinding = binding.copy();
+                    newBinding._from = finalPath;
                     newBinding.connect(view);
+                    // Make debugging easier
+                    binding._resolved_form = newBinding._resolved_form = newBinding._from;
+                    binding._unresolved_form = newBinding._unresolved_form = binding._from;
                 }
             }
         }


### PR DESCRIPTION
This way stuff like oneway-transformations work.
Also added properties _resolved_form and _unresolved_form to help debugging bindings.
