### PR TITLE
tableDataView renders the nulls same way in _renderTable and _cellsDidCh...

### DIFF
--- a/views/table_data_view.js
+++ b/views/table_data_view.js
@@ -520,11 +520,15 @@ Flame.TableDataView = Flame.View.extend(Flame.Statechart, {
         for (i = 0; i < rowCount; i++) {
             buffer.push('<tr data-index="'+i+'">');
             for (j = 0; j < columnCount; j++) {
-                var cell = data[i][j];
-                var cssClassesString = cell ? cell.cssClassesString() : "";
                 var content;
-                if(cell){
-                    content = (Ember.none(cell.content()) ? '' : cell.content());
+                var cell = data[i][j];
+                var cssClassesString = '';
+                var titleValue = '';
+                if (cell) {
+                    content = cell.content();
+                    content = (Ember.none(content) ? '' : content);
+                    cssClassesString = cell.cssClassesString();
+                    titleValue = (cell.titleValue && cell.titleValue() ? 'title="%@"'.fmt(cell.titleValue()) : '');
                 } else {
                     content = '<span style="color: #999">...</span>';
                 }
@@ -535,7 +539,7 @@ Flame.TableDataView = Flame.View.extend(Flame.Statechart, {
                         j,
                         (cssClassesString + (j % 2 === 0 ? " even-col" : " odd-col")),
                         cellWidth,
-                        (cell && cell.titleValue && cell.titleValue() ? 'title="%@"'.fmt(cell.titleValue()) : ''),
+                        titleValue,
                         content));
             }
             buffer.push("</tr>");


### PR DESCRIPTION
Table data view handles the cell contents differently when cell is rendered via TableDataView#_renderTable and TableDataView#_cellsDidChange. The former won't check the contents for null while latter will, and will replace null with empty string.
