### PR TITLE
Fix menus appearing out of window

### DIFF
--- a/views/menu_view.js
+++ b/views/menu_view.js
@@ -217,7 +217,7 @@ Flame.MenuView = Flame.Panel.extend(Flame.ActionSupport, {
         this._super(anchorElement, position);
         this.set("_anchorElement", anchorElement);
         this._updateMenuSize();
-        this._layoutRelativeTo();
+        this._layoutRelativeTo(anchorElement, position);    // re-layout now that width has been computed
     },
 
     _updateMenuSize: function() {


### PR DESCRIPTION
I don't know if this is the right way to fix this, but when I updated to the current Flame from v0.2.1, my menus and submenus weren't being constrained to appear within the window any more. _layoutRelativeTo() is called above in this._super(..), but the layout width isn't set at that time.
I can set an explicit width for my menu, causing it to appear, but I don't see how to set an explicit width for submenus. If there's a better way to fix this, please let me know.  Thanks!
