### PR TITLE
Fix Ember.object.create API change

### DIFF
--- a/mixins/event_manager.js
+++ b/mixins/event_manager.js
@@ -77,7 +77,7 @@ Ember.mixin(Flame, {
       that the previously focused view will re-gain the focus as soon as the modal element is closed. So if the
       previously focused view was e.g. in the middle of some edit operation, it shouldn't cancel that operation.
     */
-    keyResponderStack: Ember.Object.create({
+    keyResponderStack: Ember.Object.extend({
         _stack: [],
 
         // Observer-friendly version of getting current
@@ -123,7 +123,7 @@ Ember.mixin(Flame, {
                 return this.push(view);
             }
         }
-    })
+    }).create()
 });
 
 // Set up a handler on the document for key events.


### PR DESCRIPTION
Ember no longer allows creating computed properties in .create().
Their advice is to .extend() and then .create()

This pull request fixes that in the only place it seems to occur in Flame.js. It should be backwards compatible.
