### PR TITLE
Preserve local focus when document focus is lost

### DIFF
--- a/mixins/focus_support.js
+++ b/mixins/focus_support.js
@@ -17,7 +17,8 @@ Flame.FocusSupport = {
 
     focusOut: function() {
         if (Flame.keyResponderStack.current() === this) {
-            this.resignKeyResponder();
+            // If focus was lost from the document, keep the "local" focus intact
+            if (document.hasFocus()) this.resignKeyResponder();
         }
     }
 };


### PR DESCRIPTION
This prevents the key responder stack from getting out of sync
