### PR TITLE
Wrap Panel popup to Ember.run to prevent problems caused by elements not being in the DOM yet

### DIFF
--- a/views/panel.js
+++ b/views/panel.js
@@ -14,7 +14,7 @@ Flame.Panel = Flame.RootView.extend({
     acceptsKeyResponder: true,
     isModal: true,
     allowClosingByClickingOutside: true,
-    allowClosingByCancelButton: true,
+    allowClosingByCancelButton: false,
     allowMoving: false,
     dimBackground: true,
     title: null,


### PR DESCRIPTION
Also allow to close Panels by typing ESC
