### PR TITLE
Do not try to access autocomplete delegate if that is not supplied

### DIFF
--- a/views/autocomplete_text_field_view.js
+++ b/views/autocomplete_text_field_view.js
@@ -32,6 +32,8 @@ Flame.AutocompleteTextFieldView = Flame.TextFieldView.extend(Flame.Statechart, F
         },
 
         doAutocompleteRequest: function(query) {
+            if (!this.getPath('owner.autocompleteDelegate')) return;
+
             if (query) {
                 this.getPath('owner.autocompleteDelegate').fetchAutocompleteResults(query, this.get('owner'));
                 this.gotoState("requesting");


### PR DESCRIPTION
 (i.e behave like normal text field view)
