### PR TITLE
Added a presence check for dataCell

### DIFF
--- a/views/table_data_view.js
+++ b/views/table_data_view.js
@@ -100,7 +100,7 @@ Flame.TableDataView = Flame.View.extend(Flame.Statechart, {
                     var cell = rows[i] && rows.eq(i).children().eq(columnIndex + j);
                     if (!cell) return;
                     var dataCell = data[rowIndex + i][columnIndex + j];
-                    if (dataCell.isEditable() && dataCell.isPastable()) {
+                    if (dataCell && dataCell.isEditable() && dataCell.isPastable()) {
                         if (dataCell.options()) {
                             var option = dataCell.options().findBy('title', field);
                             if (!option) {


### PR DESCRIPTION
Trying to paste more columns than currently in the table would result in an explosion, because `dataCell` ended up being `undefined`. 
