### PR TITLE
Defer manipulation of the DOM to afterRender-stage. This prevents errors...

### DIFF
--- a/views/lazy_list_view.js
+++ b/views/lazy_list_view.js
@@ -33,6 +33,7 @@ Flame.LazyListView = Flame.ListView.extend({
 
     _lastScrollHeight: undefined,
     _lastScrollTop: undefined,
+    _recycledViews: null, // set in init
 
     init: function() {
         this._super();

--- a/views/lazy_tree_item_view.js
+++ b/views/lazy_tree_item_view.js
@@ -13,7 +13,9 @@ Flame.LazyTreeItemView = Flame.LazyListItemView.extend({
     }.property('itemContent'),
 
     isExpandedDidChange: function() {
-        this.$().find('img').first().replaceWith(this.get('disclosureImage'));
+        Ember.run.schedule('afterRender', this, function() {
+            this.$().find('img').first().replaceWith(this.get('disclosureImage'));
+        });
     }.observes('isExpanded'),
 
     isExpandable: function() {


### PR DESCRIPTION
... when LazyList is modified multiple times without rendering it to DOM in-between.

Now using scheduleOnce.
