### PR TITLE
XSS fixes

### DIFF
--- a/utils/string_measurement.js
+++ b/utils/string_measurement.js
@@ -19,9 +19,19 @@ Ember.mixin(Flame, {
         return element;
     },
 
-    measureString: function(string, parentClasses, elementClasses, additionalStyles) {
+    measureString: function(stringOrArray, parentClasses, elementClasses, additionalStyles) {
+        var escape = Handlebars.Utils.escapeExpression;
+        var measuredString;
+        // We also accept an array of strings and then return the width of the longest one by joining them with <br>.
+        if (Ember.isArray(stringOrArray)) {
+            measuredString = stringOrArray.reduce(function(currentStrings, nextString) {
+                        return currentStrings + escape(nextString) + '<br>';
+                    }, '');
+        } else {
+            measuredString = escape(stringOrArray);
+        }
         var element = this._setupStringMeasurement(parentClasses, elementClasses, additionalStyles);
-        element.innerHTML = string;
+        element.innerHTML = measuredString;
         return {
             width: element.clientWidth,
             height: element.clientHeight

--- a/views/checkbox_view.js
+++ b/views/checkbox_view.js
@@ -9,7 +9,7 @@ Flame.CheckboxView = Flame.ButtonView.extend({
         buffer.push('<div class="flame-checkbox-box"></div>');
         this.renderCheckMark(buffer);
         buffer.push('<label class="flame-checkbox-label">');
-        buffer.push(Ember.isNone(this.get('title')) ? '' : this.get('title'));
+        buffer.push(Ember.isNone(this.get('title')) ? '' : Handlebars.Utils.escapeExpression(this.get('title')));
         buffer.push('</label>');
     },
 

--- a/views/menu_view.js
+++ b/views/menu_view.js
@@ -103,10 +103,7 @@ Flame.MenuView = Flame.Panel.extend(Flame.ActionSupport, {
             return;
         }
         var itemTitleKey = this.get('itemTitleKey');
-        var allTitles = items.reduce(function(currentTitles, item) {
-            var nextTitle = Ember.get(item, itemTitleKey);
-            return currentTitles + nextTitle + '<br>';
-        }, '');
+        var allTitles = items.map(function(currentTitles, item) { Ember.get(item, itemTitleKey); });
         // Give the menus a 16px breathing space to account for sub menu indicator, and to give some right margin (+18px for the padding)
         return Flame.measureString(allTitles, 'ember-view flame-view flame-list-item-view flame-menu-item-view', 'title').width + 16 + 18;
     },

--- a/views/table_data_view.js
+++ b/views/table_data_view.js
@@ -456,7 +456,7 @@ Flame.TableDataView = Flame.View.extend(Flame.Statechart, {
             var owner = this.get('owner');
             var selection = owner.get('selection');
             var dataCell = owner.get('selectedDataCell');
-            var readOnlyValue = owner.editableValue(dataCell, true);
+            var readOnlyValue = Handlebars.Utils.escapeExpression(owner.editableValue(dataCell, true));
             this.selectionContent = selection.html();
             selection.html(readOnlyValue);
             selection.addClass('read-only is-selectable');
@@ -797,6 +797,7 @@ Flame.TableDataView = Flame.View.extend(Flame.Statechart, {
         var defaultCellWidth = this.get('parentView.defaultColumnWidth');
         var columnLeafs = this.get('parentView.content.columnLeafs');
         var cellWidth;
+        var escape = Handlebars.Utils.escapeExpression;
 
         var classes = 'flame-table';
         if (!this.get('parentView.allowSelection')) classes += ' is-selectable';
@@ -818,10 +819,13 @@ Flame.TableDataView = Flame.View.extend(Flame.Statechart, {
                         while (div.firstChild) div.removeChild(div.firstChild);
                         div.appendChild(content);
                         content = div.innerHTML;
+                    } else {
+                        // Escape the cell content unless there is a deliberate implementation for cells with HTML content.
+                        content = escape(content);
                     }
                     cssClassesString = cell.cssClassesString();
                     if (cell.inlineStyles) inlineStyles = cell.inlineStyles();
-                    titleValue = (cell.titleValue && cell.titleValue() ? 'title="%@"'.fmt(cell.titleValue()) : '');
+                    titleValue = (cell.titleValue && cell.titleValue() ? 'title="%@"'.fmt(escape(cell.titleValue())) : '');
                 } else {
                     content = '<span style="color: #999">...</span>';
                 }

--- a/views/table_view.js
+++ b/views/table_view.js
@@ -319,7 +319,7 @@ Flame.TableView = Flame.View.extend(Flame.Statechart, {
         }
 
         if (this.get('content.title')) {
-            buffer.push('<div class="panel-title">%@</div>'.fmt(this.get('content.title')));
+            buffer.push('<div class="panel-title">%@</div>'.fmt(Handlebars.Utils.escapeExpression(this.get('content.title'))));
             didRenderTitle = true;
         }
 
@@ -438,7 +438,8 @@ Flame.TableView = Flame.View.extend(Flame.Statechart, {
 
             headerLabel = header.get ? header.get('headerLabel') : header.label;
             if (!headerLabel) headerLabel = "";
-
+            // We have to support <br> for row headers, so we'll replace them back after escaping
+            headerLabel = Ember.Handlebars.Utils.escapeExpression(headerLabel).replace(/&lt;br&gt;/g, '<br>');
             buffer.attr('title', headerLabel.replace(/<br>/g, '\n'));
 
             if (header.rowspan > 1) {


### PR DESCRIPTION
-Patch render calls in CheckboxView, TableView and TableDataView to display escaped content; preserve <br> tags in table headers in TableView
-Escape the innerHTML call in string_measurement.js
-Escape element.html call when selecting read-only content in TableDataView